### PR TITLE
Ensure the android app foregrounds when tapping a notification

### DIFF
--- a/src/android/com/adobe/phonegap/push/PushPlugin.java
+++ b/src/android/com/adobe/phonegap/push/PushPlugin.java
@@ -611,7 +611,9 @@ public class PushPlugin extends CordovaPlugin implements PushConstants {
   }
 
   public static boolean isActive() {
-    return gWebView != null;
+    // return gWebView != null;
+    // Force the main activity to always re-launch if the app's not in the foreground
+    return isInForeground();
   }
 
   protected static void setRegistrationID(String token) {


### PR DESCRIPTION
The prior way of accomplishing this was to check if the webview still
exists, but when the app's in the background and has not been force
closed it will exist. This was preventing the app from foregrounding


<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.